### PR TITLE
WIP: Implement saving particle systems to and loading from JSON

### DIFF
--- a/apps/test-app-color-interpolation.ts
+++ b/apps/test-app-color-interpolation.ts
@@ -12,7 +12,6 @@ document.body.style.width = "100vw";
 document.body.style.height = "100vh";
 
 const particleSystem = new ParticleSystem();
-const renderer = new Renderer(document.body, particleSystem);
 
 const lifetimeRange = new LifeTimeRange(particleSystem);
 lifetimeRange.min = 5;
@@ -31,23 +30,33 @@ randomVelocity.randomX = { min: -20, max: 20 };
 randomVelocity.randomY = { min: -20, max: 20 };
 particleSystem.modules.push(randomVelocity);
 
-// NOTE: This SHOULD be done in a module.
-// "color over lifetime"
-const alpha = 1;
-setInterval(() => {
-    particleSystem.particles.forEach((particle) => {
-        const cycle = 5000;
-        const asd = performance.now() % (cycle * 2);
-        const lerpFactor = asd < cycle ? asd / cycle : 1 - (asd - cycle) / cycle;
-        particle.scale = 0.4;
-        particle.alpha = alpha;
-        particle.color = lerpColor({ r: 1, g: 0, b: 0 }, { r: 0, g: 1, b: 0 }, lerpFactor);
-    });
-}, 1000 / 60);
+setTimeout(() => {
+    const obj = particleSystem.toObject();
+    console.log(obj);
 
-const loader = PIXI.Loader.shared;
-loader.add("spritesheet", "./assets/kenney_particlePack.json");
-loader.onComplete.once(() => {
-    renderer.setEffectTextures(PIXI.utils.TextureCache["circle_05.png"]);
-});
-loader.load();
+    setTimeout(() => {
+        const loadParticleSystem = ParticleSystem.fromObject(obj);
+        const renderer = new Renderer(document.body, loadParticleSystem);
+
+        // NOTE: This SHOULD be done in a module.
+        // "color over lifetime"
+        const alpha = 1;
+        setInterval(() => {
+            loadParticleSystem.particles.forEach((particle) => {
+                const cycle = 5000;
+                const asd = performance.now() % (cycle * 2);
+                const lerpFactor = asd < cycle ? asd / cycle : 1 - (asd - cycle) / cycle;
+                particle.scale = 0.4;
+                particle.alpha = alpha;
+                particle.color = lerpColor({ r: 1, g: 0, b: 0 }, { r: 0, g: 1, b: 0 }, lerpFactor);
+            });
+        }, 1000 / 60);
+
+        const loader = PIXI.Loader.shared;
+        loader.add("spritesheet", "./assets/kenney_particlePack.json");
+        loader.onComplete.once(() => {
+            renderer.setEffectTextures(PIXI.utils.TextureCache["circle_05.png"]);
+        });
+        loader.load();
+    }, 1000);
+}, 1000);

--- a/src/core/destructors/alphaDestructor.ts
+++ b/src/core/destructors/alphaDestructor.ts
@@ -1,3 +1,4 @@
+import { ModuleObject } from "core/particleSystem";
 import { Module } from "../module";
 /**
  * `Module` that destroys all particles whose color alpha value is less or equal to 0
@@ -11,5 +12,13 @@ export class AlphaDestructor extends Module {
                 this.parentSystem.destroyParticle(particle);
             }
         }
+    }
+
+    /**
+     * Wrap the properties of the module into a JSON containing only primitive JavaScript data types
+     * (such as numbers, strings, etc.) that can be serialized into strings natively.
+     */
+    toObject(): ModuleObject {
+        throw new Error("Unimplemented method");
     }
 }

--- a/src/core/destructors/lifeTimeDestructor.ts
+++ b/src/core/destructors/lifeTimeDestructor.ts
@@ -1,3 +1,5 @@
+import { moduleToObject, moduleTypeRegistry, objectToModule } from "core/moduleTypeRegistry";
+import { ModuleObject, ParticleSystem } from "core/particleSystem";
 import { Module } from "../module";
 
 export class LifeTimeDestructor extends Module {
@@ -10,4 +12,30 @@ export class LifeTimeDestructor extends Module {
             }
         }
     }
+
+    /**
+     * Wrap the properties of the module into a JSON containing only primitive JavaScript data types
+     * (such as numbers, strings, etc.) that can be serialized into strings natively.
+     */
+    toObject(): ModuleObject {
+        return moduleToObject(LifeTimeDestructor, [], this);
+    }
+
+    static fromObject(particleSystem: ParticleSystem, object: ModuleObject): LifeTimeDestructor {
+        return objectToModule(LifeTimeDestructor, [], object, particleSystem);
+    }
+
+    /**
+     * Serializable identifier for the module.
+     *
+     * This must be unique between all existing Modules in the library.
+     */
+    static moduleTypeId = "LifeTimeDestructor";
 }
+
+/**
+ * Include the Module in a registry containing all Module types in the library.
+ *
+ * This is necessary for loading modules from objects.
+ */
+moduleTypeRegistry.push(LifeTimeDestructor);

--- a/src/core/destructors/outsideBoundsDestructor.ts
+++ b/src/core/destructors/outsideBoundsDestructor.ts
@@ -1,4 +1,4 @@
-import { ParticleSystem } from "core/particleSystem";
+import { ModuleObject, ParticleSystem } from "core/particleSystem";
 import { Shape } from "core/shapes/shape";
 import { Module } from "../module";
 
@@ -36,5 +36,13 @@ export class OutsideBoundsDestructor extends Module {
                 this.parentSystem.destroyParticle(particle);
             }
         }
+    }
+
+    /**
+     * Wrap the properties of the module into a JSON containing only primitive JavaScript data types
+     * (such as numbers, strings, etc.) that can be serialized into strings natively.
+     */
+    toObject(): ModuleObject {
+        throw new Error("Unimplemented method");
     }
 }

--- a/src/core/generators/circleExteriorGenerator.ts
+++ b/src/core/generators/circleExteriorGenerator.ts
@@ -1,6 +1,7 @@
 import { Position } from "../types";
 import { Particle } from "../particle";
 import { ParticleGenerator } from "./generator";
+import { ModuleObject } from "core/particleSystem";
 
 // NOTE: Ideally we would have a class for `CircleGenerator`, where user could configure whether to generate particles inside the circle or along the exterior.
 // `generator.onlyExterior = true` or something like this.
@@ -39,5 +40,13 @@ export class CircleExteriorGenerator extends ParticleGenerator {
         this.nextParticleAngle += this.angleStep;
 
         this.parentSystem.addParticle(particle);
+    }
+
+    /**
+     * Wrap the properties of the module into a JSON containing only primitive JavaScript data types
+     * (such as numbers, strings, etc.) that can be serialized into strings natively.
+     */
+    toObject(): ModuleObject {
+        throw new Error("Unimplemented method");
     }
 }

--- a/src/core/generators/pointGenerator.ts
+++ b/src/core/generators/pointGenerator.ts
@@ -1,6 +1,8 @@
 import { Position } from "../types";
 import { Particle } from "../particle";
 import { ParticleGenerator } from "./generator";
+import { ModuleObject, ParticleSystem } from "core/particleSystem";
+import { moduleTypeRegistry, moduleToObject, objectToModule } from "core/moduleTypeRegistry";
 
 export class PointGenerator extends ParticleGenerator {
     position: Position = { x: 0, y: 0 };
@@ -12,4 +14,30 @@ export class PointGenerator extends ParticleGenerator {
 
         this.parentSystem.addParticle(particle);
     }
+
+    /**
+     * Wrap the properties of the module into a JSON containing only primitive JavaScript data types
+     * (such as numbers, strings, etc.) that can be serialized into strings natively.
+     */
+    toObject(): ModuleObject {
+        return moduleToObject(PointGenerator, ["interval", "position"], this);
+    }
+
+    static fromObject(particleSystem: ParticleSystem, object: ModuleObject): PointGenerator {
+        return objectToModule(PointGenerator, ["interval", "position"], object, particleSystem);
+    }
+
+    /**
+     * Serializable identifier for the module.
+     *
+     * This must be unique between all existing Modules in the library.
+     */
+    static moduleTypeId = "PointGenerator";
 }
+
+/**
+ * Include the Module in a registry containing all Module types in the library.
+ *
+ * This is necessary for loading modules from objects.
+ */
+moduleTypeRegistry.push(PointGenerator);

--- a/src/core/initializers/alphaRange.ts
+++ b/src/core/initializers/alphaRange.ts
@@ -2,6 +2,7 @@ import { Module } from "../module";
 import { Particle } from "../particle";
 import { Range } from "../types";
 import { randomInRange } from "core/utilities";
+import { ModuleObject } from "core/particleSystem";
 
 /**
  * Module which overrides `Particle.color.a` property from a configurable random value range.
@@ -27,4 +28,12 @@ export class AlphaRange extends Module {
     handleParticleAdd = (particle: Particle): void => {
         particle.alpha = randomInRange(this.min, this.max);
     };
+
+    /**
+     * Wrap the properties of the module into a JSON containing only primitive JavaScript data types
+     * (such as numbers, strings, etc.) that can be serialized into strings natively.
+     */
+    toObject(): ModuleObject {
+        throw new Error("Unimplemented method");
+    }
 }

--- a/src/core/initializers/lifeTimeRange.ts
+++ b/src/core/initializers/lifeTimeRange.ts
@@ -1,6 +1,8 @@
 import { Module } from "../module";
 import { Particle } from "../particle";
 import { lerp } from "core/utilities";
+import { ModuleObject, ParticleSystem } from "core/particleSystem";
+import { moduleToObject, moduleTypeRegistry, objectToModule } from "core/moduleTypeRegistry";
 
 export class LifeTimeRange extends Module {
     min = 1.5;
@@ -15,4 +17,30 @@ export class LifeTimeRange extends Module {
     handleParticleAdd = (particle: Particle): void => {
         particle.lifeTime = lerp(this.min, this.max, Math.random());
     };
+
+    /**
+     * Wrap the properties of the module into a JSON containing only primitive JavaScript data types
+     * (such as numbers, strings, etc.) that can be serialized into strings natively.
+     */
+    toObject(): ModuleObject {
+        return moduleToObject(LifeTimeRange, ["min", "max"], this);
+    }
+
+    static fromObject(particleSystem: ParticleSystem, object: ModuleObject): LifeTimeRange {
+        return objectToModule(LifeTimeRange, ["min", "max"], object, particleSystem);
+    }
+
+    /**
+     * Serializable identifier for the module.
+     *
+     * This must be unique between all existing Modules in the library.
+     */
+    static moduleTypeId = "LifeTimeRange";
 }
+
+/**
+ * Include the Module in a registry containing all Module types in the library.
+ *
+ * This is necessary for loading modules from objects.
+ */
+moduleTypeRegistry.push(LifeTimeRange);

--- a/src/core/initializers/randomAngleVelocity.ts
+++ b/src/core/initializers/randomAngleVelocity.ts
@@ -1,6 +1,7 @@
 import { Module } from "../module";
 import { Particle } from "../particle";
 import { randomInRange } from "core/utilities";
+import { ModuleObject } from "core/particleSystem";
 
 /**
  * Module that assigns a random velocity to each particle along a random direction.
@@ -25,4 +26,12 @@ export class RandomAngleVelocity extends Module {
         particle.velocity.x = Math.cos(angleRad) * velocity;
         particle.velocity.y = Math.sin(angleRad) * velocity;
     };
+
+    /**
+     * Wrap the properties of the module into a JSON containing only primitive JavaScript data types
+     * (such as numbers, strings, etc.) that can be serialized into strings natively.
+     */
+    toObject(): ModuleObject {
+        throw new Error("Unimplemented method");
+    }
 }

--- a/src/core/initializers/randomVelocity.ts
+++ b/src/core/initializers/randomVelocity.ts
@@ -2,6 +2,8 @@ import { Range } from "../types";
 import { Module } from "../module";
 import { Particle } from "../particle";
 import { lerp } from "core/utilities";
+import { ModuleObject, ParticleSystem } from "core/particleSystem";
+import { moduleToObject, moduleTypeRegistry, objectToModule } from "core/moduleTypeRegistry";
 
 export class RandomVelocity extends Module {
     randomX: Range = { min: 100, max: 100 };
@@ -15,4 +17,30 @@ export class RandomVelocity extends Module {
         particle.velocity.x = lerp(this.randomX.min, this.randomX.max, Math.random());
         particle.velocity.y = lerp(this.randomY.min, this.randomY.max, Math.random());
     };
+
+    /**
+     * Wrap the properties of the module into a JSON containing only primitive JavaScript data types
+     * (such as numbers, strings, etc.) that can be serialized into strings natively.
+     */
+    toObject(): ModuleObject {
+        return moduleToObject(RandomVelocity, ["randomX", "randomY"], this);
+    }
+
+    static fromObject(particleSystem: ParticleSystem, object: ModuleObject): RandomVelocity {
+        return objectToModule(RandomVelocity, ["randomX", "randomY"], object, particleSystem);
+    }
+
+    /**
+     * Serializable identifier for the module.
+     *
+     * This must be unique between all existing Modules in the library.
+     */
+    static moduleTypeId = "RandomVelocity";
 }
+
+/**
+ * Include the Module in a registry containing all Module types in the library.
+ *
+ * This is necessary for loading modules from objects.
+ */
+moduleTypeRegistry.push(RandomVelocity);

--- a/src/core/modifiers/alphaOverLifetime.ts
+++ b/src/core/modifiers/alphaOverLifetime.ts
@@ -1,4 +1,5 @@
 import { EasingFunction, EasingFunctions } from "core/easing";
+import { ModuleObject } from "core/particleSystem";
 import { Module } from "../module";
 
 /**
@@ -25,5 +26,13 @@ export class AlphaOverLifetime extends Module {
             const alpha = 1 - this.easing(particle.timeLived / particle.lifeTime);
             particle.alpha = alpha;
         }
+    }
+
+    /**
+     * Wrap the properties of the module into a JSON containing only primitive JavaScript data types
+     * (such as numbers, strings, etc.) that can be serialized into strings natively.
+     */
+    toObject(): ModuleObject {
+        throw new Error("Unimplemented method");
     }
 }

--- a/src/core/modifiers/deaccelerationOverLifetime.ts
+++ b/src/core/modifiers/deaccelerationOverLifetime.ts
@@ -1,5 +1,6 @@
 import { EasingFunction, EasingFunctions } from "core/easing";
 import { Particle } from "core/particle";
+import { ModuleObject } from "core/particleSystem";
 import { Velocity } from "core/types";
 import { vec2 } from "core/utilities";
 import { Module } from "../module";
@@ -58,5 +59,13 @@ export class DeaccelerationOverLifetime extends Module {
             particle.velocity.x -= deacceleration.x;
             particle.velocity.y -= deacceleration.y;
         }
+    }
+
+    /**
+     * Wrap the properties of the module into a JSON containing only primitive JavaScript data types
+     * (such as numbers, strings, etc.) that can be serialized into strings natively.
+     */
+    toObject(): ModuleObject {
+        throw new Error("Unimplemented method");
     }
 }

--- a/src/core/modifiers/gravity.ts
+++ b/src/core/modifiers/gravity.ts
@@ -1,3 +1,4 @@
+import { ModuleObject } from "core/particleSystem";
 import { Module } from "../module";
 
 export class Gravity extends Module {
@@ -7,5 +8,13 @@ export class Gravity extends Module {
         this.parentSystem.particles.forEach((particle) => {
             particle.velocity.y += this.strength;
         });
+    }
+
+    /**
+     * Wrap the properties of the module into a JSON containing only primitive JavaScript data types
+     * (such as numbers, strings, etc.) that can be serialized into strings natively.
+     */
+    toObject(): ModuleObject {
+        throw new Error("Unimplemented method");
     }
 }

--- a/src/core/module.ts
+++ b/src/core/module.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
-import { ParticleSystem } from "./particleSystem";
+import { ModuleObject, ParticleSystem } from "./particleSystem";
 
 export abstract class Module {
     active = true;
@@ -11,4 +11,10 @@ export abstract class Module {
 
     init(): void {}
     update(dt: number): void {}
+
+    /**
+     * Wrap the properties of the module into a JSON containing only primitive JavaScript data types
+     * (such as numbers, strings, etc.) that can be serialized into strings natively.
+     */
+    abstract toObject(): ModuleObject;
 }

--- a/src/core/moduleTypeRegistry.ts
+++ b/src/core/moduleTypeRegistry.ts
@@ -1,0 +1,63 @@
+import { Module } from "./module";
+import { ModuleObject, ParticleSystem } from "./particleSystem";
+
+/**
+ * TODO
+ */
+interface ModuleTypeReference {
+    /**
+     * Serializable identifier for the module.
+     *
+     * This must be unique between all existing Modules in the library.
+     */
+    moduleTypeId: string;
+
+    fromObject(particleSystem: ParticleSystem, object: object): Module;
+}
+
+/**
+ * TODO
+ */
+export const moduleTypeRegistry: ModuleTypeReference[] = [];
+
+/**
+ * TODO
+ */
+export const moduleToObject = <ModuleType extends ModuleTypeReference, ModuleInstanceType>(
+    moduleType: ModuleType,
+    savedProperties: Array<keyof ModuleInstanceType>,
+    module: ModuleInstanceType,
+): ModuleObject => {
+    const obj: ModuleObject = {
+        moduleTypeId: moduleType.moduleTypeId,
+    };
+    savedProperties.forEach((property) => {
+        obj[property] = module[property];
+    });
+    return obj;
+};
+
+/**
+ * TODO
+ */
+export const objectToModule = <
+    ModuleType extends ModuleTypeReference & { new (particleSystem: ParticleSystem): ModuleInstanceType },
+    ModuleInstanceType,
+>(
+    moduleType: ModuleType,
+    loadedProperties: Array<keyof ModuleInstanceType>,
+    object: ModuleObject,
+    particleSystem: ParticleSystem,
+): ModuleInstanceType => {
+    const module = new moduleType(particleSystem);
+    loadedProperties.forEach((property) => {
+        const value = object[property];
+        if (!value) {
+            // This probably means that the module was saved with a different library version than the active one.
+            console.warn(`${moduleType.moduleTypeId} property could not be loaded: "${property}"`);
+            return;
+        }
+        module[property] = value as ModuleInstanceType[typeof property];
+    });
+    return module;
+};

--- a/src/core/particleSystem.ts
+++ b/src/core/particleSystem.ts
@@ -1,4 +1,5 @@
 import { Module } from "./module";
+import { moduleTypeRegistry } from "./moduleTypeRegistry";
 import { Particle } from "./particle";
 
 export class ParticleSystem {
@@ -58,4 +59,42 @@ export class ParticleSystem {
             clbk(particle);
         });
     }
+
+    /**
+     * Wrap the properties of the whole particle system into a JSON containing only primitive JavaScript data types
+     * (such as numbers, strings, etc.) that can be serialized into strings natively.
+     */
+    toObject(): ParticleSystemObject {
+        return {
+            modules: this.modules.map((module) => module.toObject()),
+        };
+    }
+
+    static fromObject(object: ParticleSystemObject): ParticleSystem {
+        const particleSystem = new ParticleSystem();
+        const moduleObjects = object.modules;
+        moduleObjects?.forEach((moduleObject) => {
+            const moduleTypeReference = moduleTypeRegistry.find(
+                (moduleType) => moduleType.moduleTypeId === moduleObject.moduleTypeId,
+            );
+            if (!moduleTypeReference) {
+                // The module type can't be identified. This probably means that the particle system was saved with a different library version than the active one.
+                console.warn(`ParticleSystem.fromObject unidentified module type: "${moduleObject.moduleTypeId}"`);
+                return;
+            }
+
+            const module = moduleTypeReference.fromObject(particleSystem, moduleObject);
+            particleSystem.modules.push(module);
+        });
+        return particleSystem;
+    }
+}
+
+interface ParticleSystemObject {
+    modules: ModuleObject[] | undefined;
+}
+
+export interface ModuleObject {
+    moduleTypeId: string | undefined;
+    [key: string | number | symbol]: unknown;
 }


### PR DESCRIPTION
Adds `ParticleSystem` methods:
- `toObject` and
- `fromObject`

These can be used to serialize particle systems including all their modules and also deserialize them back.

Adds a bunch of extra responsibilities that need to be handled in implementation of each `Module`