### PR TITLE
Add rectangle generator

### DIFF
--- a/modular-particle-system/src/generators/shapeGenerator.ts
+++ b/modular-particle-system/src/generators/shapeGenerator.ts
@@ -1,0 +1,58 @@
+import { ModuleObject } from "../module";
+import { loadSerializedProperty, deserializePrimitiveDataType } from "../serialization/moduleSerialization";
+import { Particle } from "../particle";
+import { ParticleEffect } from "../particleEffect";
+import { ParticleGenerator } from "./generator";
+import { deserializeShape, getRandomPositionInsideShape, serializeShape, Shape } from "../shapes/shape";
+
+/**
+ * Module that can be used to generate particles with an initial position inside a generic _Shape_.
+ *
+ * Shape is assigned via `ShapeGenerator.shape` property, for example:
+ *
+ * ```ts
+ *  const generator = new ShapeGenerator(particleEffect)
+ *  generator.shape = {
+ *      type: 'rectangle',
+ *      v1: { x: 100, y: 100 },
+ *      v2: { x: 300, y: 500 }
+ *  }
+ * ```
+ */
+export class ShapeGenerator extends ParticleGenerator {
+    shape?: Shape;
+
+    generateParticle() {
+        const particle = new Particle();
+        if (this.shape) {
+            particle.position = getRandomPositionInsideShape(this.shape);
+        }
+        this.particleEffect.addParticle(particle);
+    }
+
+    /**
+     * Wrap the properties of the module into a JSON containing only primitive JavaScript data types
+     * (such as numbers, strings, etc.) that can be serialized into strings natively.
+     */
+    toObject(): ModuleObject {
+        return {
+            moduleTypeId: ShapeGenerator.moduleTypeId,
+            interval: this.interval,
+            shape: this.shape ? serializeShape(this.shape) : undefined,
+        };
+    }
+
+    static fromObject(particleEffect: ParticleEffect, object: ModuleObject): ShapeGenerator {
+        const module = new ShapeGenerator(particleEffect);
+        loadSerializedProperty(object, ShapeGenerator, module, "interval", deserializePrimitiveDataType);
+        loadSerializedProperty(object, ShapeGenerator, module, "shape", deserializeShape);
+        return module;
+    }
+
+    /**
+     * Serializable identifier for the module.
+     *
+     * This must be unique between all existing Modules in the library.
+     */
+    static moduleTypeId = "ShapeGenerator";
+}

--- a/modular-particle-system/src/shapes/rectangle.ts
+++ b/modular-particle-system/src/shapes/rectangle.ts
@@ -1,0 +1,34 @@
+import { Position } from "../types";
+import { ShapeLogicImplementation } from "./shape";
+
+export interface Rectangle {
+    type: "rectangle";
+    v1: Position;
+    v2: Position;
+}
+
+export const rectangleLogic: ShapeLogicImplementation<Rectangle> = {
+    /**
+     * Get unbiased random position within the Shape.
+     * @return      Random position within the Shape.
+     */
+    getRandomPosition(shape: Rectangle): Position {
+        return {
+            x: shape.v1.x + Math.random() * (shape.v2.x - shape.v1.x),
+            y: shape.v1.y + Math.random() * (shape.v2.y - shape.v1.y),
+        };
+    },
+
+    /**
+     * Check whether a position is within the Shape or not.
+     * @param   position    Position to check.
+     * @return              `true` if `position` is inside the shape, otherwise `false`.
+     */
+    containsPosition(shape: Rectangle, position: Position): boolean {
+        const minX = Math.min(shape.v1.x, shape.v2.x);
+        const minY = Math.min(shape.v1.y, shape.v2.y);
+        const maxX = Math.max(shape.v1.x, shape.v2.x);
+        const maxY = Math.max(shape.v1.y, shape.v2.y);
+        return position.x >= minX && position.x <= maxX && position.y >= minY && position.y <= maxY;
+    },
+};

--- a/modular-particle-system/src/shapes/shape.ts
+++ b/modular-particle-system/src/shapes/shape.ts
@@ -1,7 +1,8 @@
 import { Position } from "../types";
+import { Rectangle, rectangleLogic } from "./rectangle";
 import { Triangle, triangleLogic } from "./triangle";
 
-export type Shape = Triangle;
+export type Shape = Triangle | Rectangle;
 
 export const serializeShape = (shape: Shape): unknown => {
     // Shapes are just primitive data types, can be serialized as they are.
@@ -25,8 +26,9 @@ const selectShapeLogic = (shape: Shape): ShapeLogicImplementation<Shape> => {
     switch (shape.type) {
         case "triangle":
             return triangleLogic;
+        case "rectangle":
+            return rectangleLogic;
     }
-    throw new Error(`Unidentified shape ${shape.type}`);
 };
 
 /**

--- a/playground/apps/test-app-gravity.ts
+++ b/playground/apps/test-app-gravity.ts
@@ -1,10 +1,10 @@
 import * as PIXI from "pixi.js";
 import { ParticleSystem } from "modular-particle-system/particleSystem";
-import { PointGenerator } from "modular-particle-system/generators/pointGenerator";
-import { RandomVelocity } from "modular-particle-system/initializers/randomVelocity";
 import { LifeTimeRange } from "modular-particle-system/initializers/lifeTimeRange";
 import { Gravity } from "modular-particle-system/modifiers/gravity";
 import { Renderer } from "./helpers/renderer/renderer";
+import { ShapeGenerator } from "modular-particle-system/generators/shapeGenerator";
+import { OutsideBoundsDestructor } from "modular-particle-system/destructors/outsideBoundsDestructor";
 
 document.body.style.margin = "0px 0px";
 document.body.style.width = "100vw";
@@ -14,22 +14,24 @@ const particleSystem = new ParticleSystem();
 const renderer = new Renderer(document.body, particleSystem);
 
 const effect = particleSystem.addParticleEffect();
-
-const generator = new PointGenerator(effect);
-generator.position = { x: window.innerWidth / 2, y: window.innerHeight / 2 };
-effect.modules.push(generator);
+const generator = new ShapeGenerator(effect)
+generator.shape = {
+    type: 'rectangle',
+    v1: { x: 0, y: 0 },
+    v2: { x: window.innerWidth, y: 0 }
+}
+effect.modules.push(generator)
 
 const initializer = new LifeTimeRange(effect);
 effect.modules.push(initializer);
 
-const randomVelocity = new RandomVelocity(effect);
-randomVelocity.randomX = { min: -50, max: 50 };
-randomVelocity.randomY = { min: -100, max: -100 };
-effect.modules.push(randomVelocity);
-
 const gravity = new Gravity(effect);
 gravity.strength = 0.2;
 effect.modules.push(gravity);
+
+const destructor = new OutsideBoundsDestructor(effect)
+destructor.bounds = {type: 'rectangle', v1:{x:0,y:0},v2:{x:window.innerWidth, y:window.innerHeight}}
+effect.modules.push(destructor)
 
 const loader = PIXI.Loader.shared;
 loader.add("spritesheet", "./assets/kenney_particlePack.json");


### PR DESCRIPTION
Closes https://github.com/Risto-Paasivirta/ParticleSystem/issues/80

- Adds `ShapeGenerator`
   - Module which can work with any generic shape (Rectangle, Triangle currently). Functions like a "rectangle generator"
- Adds `Rectangle` shape implementation.  