### PR TITLE
Fix deserializing 0 number value not working

### DIFF
--- a/modular-particle-system/package-lock.json
+++ b/modular-particle-system/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "modular-particle-system",
-    "version": "0.1.1",
+    "version": "0.2.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "modular-particle-system",
-            "version": "0.1.1",
+            "version": "0.2.3",
             "license": "MIT",
             "devDependencies": {
                 "@types/jest": "^27.4.0",

--- a/modular-particle-system/package.json
+++ b/modular-particle-system/package.json
@@ -1,6 +1,6 @@
 {
     "name": "modular-particle-system",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "homepage": "https://github.com/Risto-Paasivirta/ParticleSystem",
     "description": "Modular particle system library",
     "browserslist": "> 0.25%, not dead",

--- a/modular-particle-system/src/serialization/moduleSerialization.ts
+++ b/modular-particle-system/src/serialization/moduleSerialization.ts
@@ -12,7 +12,7 @@ export const loadSerializedProperty = <
     deserializeValue: (value: unknown) => ModuleInstanceType[typeof key] | undefined,
 ): void => {
     const value = object[key as keyof object];
-    if (!value) {
+    if (value === undefined) {
         console.warn(`Missing module property ${moduleType.moduleTypeId}: "${key}"`);
         return;
     }


### PR DESCRIPTION
Loading module from JSON didn't work when there was a number value with exactly `0` value.

Instead of 0 the property was set to its default value.