### PR TITLE
Fix gh pages deployment on master

### DIFF
--- a/.github/workflows/update-gh-pages.yml
+++ b/.github/workflows/update-gh-pages.yml
@@ -6,8 +6,7 @@ name: Update GitHub Pages
 on:
   push:
     branches:
-      - main  # Set a branch name to trigger deployment
-      - nk/proto-editor   # TODO: Remove after confirmed to work
+      - master # Set a branch name to trigger deployment
   pull_request:
 
   # Allows you to run this workflow manually from the Actions tab


### PR DESCRIPTION
Automatic CD configuration has wrong branch name (`main`) instead of `master`, so it is not triggered when master is updated.

This fixes it.