### PR TITLE
Add lifetime destructor to default effect editor config

### DIFF
--- a/editor/src/components/Editor.js
+++ b/editor/src/components/Editor.js
@@ -138,6 +138,9 @@ const defaultParticleSystemConf = [
       {
         moduleTypeId: "AlphaOverLifetime",
       },
+      {
+        moduleTypeId: "LifeTimeDestructor",
+      },
     ],
   },
 ];


### PR DESCRIPTION
When opening effect editor app, there is now life destructor module added automatically (to avoid problem with particles never being destroyed)