### PR TITLE
Add category information to Editor modules

### DIFF
--- a/editor/readCoreLibraryVersion.js
+++ b/editor/readCoreLibraryVersion.js
@@ -16,13 +16,15 @@ const readModules = () => {
     path.resolve(pathModularParticleSystem, "initializers/"),
     path.resolve(pathModularParticleSystem, "modifiers/"),
   ];
+  const moduleNameBlacklist = ["generator.d.ts"];
 
   const moduleFiles = modulePaths
     .map((modulePath) =>
       fs.readdirSync(modulePath).map((file) => path.resolve(modulePath, file))
     )
     .flat()
-    .filter((file) => file.endsWith("d.ts"));
+    .filter((file) => file.endsWith("d.ts"))
+    .filter((file) => !moduleNameBlacklist.includes(file));
 
   const particleModules = moduleFiles.map((moduleFile) => {
     const moduleTypeDef = fs.readFileSync(moduleFile).toString();
@@ -35,6 +37,7 @@ const readModules = () => {
     };
 
     const regexpModulePropertiesBlocks = /@module((.|\s)*?)\*\//g;
+    const regexpModuleInfoTags = /@(category)\s+(.*)/g;
     const regexpModulePropertyBlock = /([^ ]+)\s?{((.|\n|\r)*?)}/g;
     const regexpModulePropertyFields = /@([^ ]*)\s+([^\n\r]*)/g;
 
@@ -44,6 +47,18 @@ const readModules = () => {
 
     matchModulePropertiesBlocks.forEach((blockMatch) => {
       const block = blockMatch[1];
+
+      // Match module info tags (for example: "@category Modifier")
+      const matchModuleInfoTags = Array.from(
+        block.matchAll(regexpModuleInfoTags)
+      );
+      matchModuleInfoTags.forEach((moduleInfoTagMatch) => {
+        const infoTagName = moduleInfoTagMatch[1];
+        const infoTagValue = moduleInfoTagMatch[2];
+        moduleData[infoTagName] = infoTagValue;
+      });
+
+      // Match property blocks (for example: "easing { ... }")
       const matchModulePropertyBlock = Array.from(
         block.matchAll(regexpModulePropertyBlock)
       );

--- a/modular-particle-system/src/destructors/alphaDestructor.ts
+++ b/modular-particle-system/src/destructors/alphaDestructor.ts
@@ -3,6 +3,9 @@ import { ParticleEffect } from "../particleEffect";
 
 /**
  * `Module` that destroys all particles whose color alpha value is less or equal to 0
+ *
+ * @module
+ * @category    Destructor
  */
 export class AlphaDestructor extends Module {
     update(dt: number): void {

--- a/modular-particle-system/src/destructors/lifeTimeDestructor.ts
+++ b/modular-particle-system/src/destructors/lifeTimeDestructor.ts
@@ -1,6 +1,10 @@
 import { Module, ModuleObject } from "../module";
 import { ParticleEffect } from "../particleEffect";
 
+/**
+ * @module
+ * @category    Destructor
+ */
 export class LifeTimeDestructor extends Module {
     update(dt: number): void {
         const len = this.particleEffect.particles.length;

--- a/modular-particle-system/src/destructors/outsideBoundsDestructor.ts
+++ b/modular-particle-system/src/destructors/outsideBoundsDestructor.ts
@@ -19,6 +19,7 @@ import { ParticleEffect } from "../particleEffect";
  * ```
  *
  * @module
+ * @category    Destructor
  * bounds {
  *      @tooltip        TODO
  *      @type           Shape

--- a/modular-particle-system/src/generators/circleEdgeGenerator.ts
+++ b/modular-particle-system/src/generators/circleEdgeGenerator.ts
@@ -9,6 +9,7 @@ import { loadSerializedProperty, deserializePrimitiveDataType } from "../seriali
  * Generator module that creates particles along the exterior of a circular area.
  *
  * @module
+ * @category    Generator
  * interval {
  *      @tooltip        TODO
  *      @type           Number

--- a/modular-particle-system/src/generators/circleExteriorGenerator.ts
+++ b/modular-particle-system/src/generators/circleExteriorGenerator.ts
@@ -14,6 +14,7 @@ import { ParticleGenerator } from "./generator";
  * Each particle is generated next to each other, so that when particles are regularly generated they move around the circle.
  *
  * @module
+ * @category    Generator
  * interval {
  *      @tooltip        TODO
  *      @type           Number

--- a/modular-particle-system/src/generators/circleGenerator.ts
+++ b/modular-particle-system/src/generators/circleGenerator.ts
@@ -9,6 +9,7 @@ import { loadSerializedProperty, deserializePrimitiveDataType } from "../seriali
  * Generator module that creates particles at random inside a circular area.
  *
  * @module
+ * @category    Generator
  * interval {
  *      @tooltip        TODO
  *      @type           Number

--- a/modular-particle-system/src/generators/circleLoadingGenerator.ts
+++ b/modular-particle-system/src/generators/circleLoadingGenerator.ts
@@ -9,6 +9,9 @@ import { loadSerializedProperty, deserializePrimitiveDataType } from "../seriali
  * Generator module that creates particles along the exterior of a circular area.
  *
  * Each particle is generated next to each other, so that when particles are regularly generated they move around the circle.
+ *
+ * @module
+ * @category    Generator
  */
 export class CircleLoadingGenerator extends ParticleGenerator {
     /**

--- a/modular-particle-system/src/generators/pointGenerator.ts
+++ b/modular-particle-system/src/generators/pointGenerator.ts
@@ -7,6 +7,7 @@ import { ParticleGenerator } from "./generator";
 
 /**
  * @module
+ * @category    Generator
  * interval {
  *      @tooltip        TODO
  *      @type           Number

--- a/modular-particle-system/src/generators/shapeGenerator.ts
+++ b/modular-particle-system/src/generators/shapeGenerator.ts
@@ -20,6 +20,7 @@ import { deserializeShape, getRandomPositionInsideShape, serializeShape, Shape }
  * ```
  *
  * @module
+ * @category    Generator
  * interval {
  *      @tooltip        TODO
  *      @type           Number

--- a/modular-particle-system/src/initializers/alphaRange.ts
+++ b/modular-particle-system/src/initializers/alphaRange.ts
@@ -10,6 +10,7 @@ import { randomInRange } from "../utilities";
  * Range can be configured with `min` and `max` properties.
  *
  * @module
+ * @category    Initializer
  * min {
  *      @tooltip        TODO
  *      @type           Number

--- a/modular-particle-system/src/initializers/lifeTimeRange.ts
+++ b/modular-particle-system/src/initializers/lifeTimeRange.ts
@@ -6,6 +6,7 @@ import { lerp } from "../utilities";
 
 /**
  * @module
+ * @category    Initializer
  * min {
  *      @tooltip        TODO
  *      @type           Number

--- a/modular-particle-system/src/initializers/randomAngleVelocity.ts
+++ b/modular-particle-system/src/initializers/randomAngleVelocity.ts
@@ -8,6 +8,7 @@ import { randomInRange } from "../utilities";
  * Module that assigns a random velocity to each particle along a random direction.
  *
  * @module
+ * @category    Initializer
  * min {
  *      @tooltip        TODO
  *      @type           Number

--- a/modular-particle-system/src/initializers/randomColor.ts
+++ b/modular-particle-system/src/initializers/randomColor.ts
@@ -22,6 +22,7 @@ import { lerpColor } from "../utilities";
  * ```
  *
  * @module
+ * @category    Initializer
  * palette {
  *      @tooltip        TODO
  *      @type           Color[]

--- a/modular-particle-system/src/initializers/randomRotationalVelocity.ts
+++ b/modular-particle-system/src/initializers/randomRotationalVelocity.ts
@@ -11,6 +11,7 @@ import { lerp } from "../utilities";
  * Rotational velocity range can be customized with `min` and `max` properties.
  *
  * @module
+ * @category    Initializer
  * min {
  *      @tooltip        TODO
  *      @type           Number

--- a/modular-particle-system/src/initializers/randomScale.ts
+++ b/modular-particle-system/src/initializers/randomScale.ts
@@ -10,6 +10,7 @@ import { lerp } from "../utilities";
  * Scale range can be customized with properties: `min` and `max`.
  *
  * @module
+ * @category    Initializer
  * min {
  *      @tooltip        TODO
  *      @type           Number

--- a/modular-particle-system/src/initializers/randomVelocity.ts
+++ b/modular-particle-system/src/initializers/randomVelocity.ts
@@ -7,6 +7,7 @@ import { Range } from "../types";
 
 /**
  * @module
+ * @category    Initializer
  * randomX {
  *      @tooltip        TODO
  *      @type           Range

--- a/modular-particle-system/src/modifiers/alphaOverLifetime.ts
+++ b/modular-particle-system/src/modifiers/alphaOverLifetime.ts
@@ -12,6 +12,7 @@ import { ParticleEffect } from "../particleEffect";
  * This module modifies `Particle.alpha` property and can not be combined with any other modifier that does so.
  *
  * @module
+ * @category    Modifier
  * easing {
  *      @tooltip        TODO
  *      @type           EasingFunction

--- a/modular-particle-system/src/modifiers/deaccelerationOverLifetime.ts
+++ b/modular-particle-system/src/modifiers/deaccelerationOverLifetime.ts
@@ -25,6 +25,7 @@ type ParticleWithInitialVelocity = Particle & {
  * This module modifies `Particle.velocity` property, but does not reassign it so this can be combined with other modules which affect particle velocity.
  *
  * @module
+ * @category    Modifier
  * easing {
  *      @tooltip        TODO
  *      @type           EasingFunction

--- a/modular-particle-system/src/modifiers/gravity.ts
+++ b/modular-particle-system/src/modifiers/gravity.ts
@@ -6,6 +6,7 @@ import { clamp, lerp, vec2 } from "../utilities";
 
 /**
  * @module
+ * @category    Modifier
  * strength {
  *      @tooltip        TODO
  *      @type           Number


### PR DESCRIPTION
In core library, module category can be documented like below:

```
/**
 * @module
 * @category    Destructor
 */
export class LifeTimeDestructor extends Module {
```

This information is passed to Editor where it can be used for categorizing modules (in separate task).

![image](https://user-images.githubusercontent.com/37183581/161378785-486e5ece-f875-4a4d-ac93-5d62434f970a.png)
