### PR TITLE
Add iife build to release version

### DIFF
--- a/modular-particle-system/package-lock.json
+++ b/modular-particle-system/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "modular-particle-system",
-    "version": "1.1.0",
+    "version": "1.1.0a",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "modular-particle-system",
-            "version": "1.1.0",
+            "version": "1.1.0a",
             "license": "MIT",
             "devDependencies": {
                 "@types/jest": "^27.4.0",
@@ -21,6 +21,7 @@
                 "jest-canvas-mock": "^2.3.1",
                 "prettier": "^2.5.1",
                 "rimraf": "^3.0.2",
+                "rollup": "^2.70.2",
                 "through2": "^2.0.5",
                 "ts-jest": "^27.1.3",
                 "tsc-esm": "^1.0.4",
@@ -2702,6 +2703,20 @@
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
             "dev": true
         },
+        "node_modules/fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
         "node_modules/function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -5057,6 +5072,21 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/rollup": {
+            "version": "2.70.2",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.2.tgz",
+            "integrity": "sha512-EitogNZnfku65I1DD5Mxe8JYRUCy0hkK5X84IlDtUs+O6JRMpRciXTzyCUuX11b5L5pvjH+OmFXiQ3XjabcXgg==",
+            "dev": true,
+            "bin": {
+                "rollup": "dist/bin/rollup"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.2"
             }
         },
         "node_modules/run-parallel": {
@@ -7944,6 +7974,13 @@
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
             "dev": true
         },
+        "fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
+            "optional": true
+        },
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -9703,6 +9740,15 @@
             "dev": true,
             "requires": {
                 "glob": "^7.1.3"
+            }
+        },
+        "rollup": {
+            "version": "2.70.2",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.2.tgz",
+            "integrity": "sha512-EitogNZnfku65I1DD5Mxe8JYRUCy0hkK5X84IlDtUs+O6JRMpRciXTzyCUuX11b5L5pvjH+OmFXiQ3XjabcXgg==",
+            "dev": true,
+            "requires": {
+                "fsevents": "~2.3.2"
             }
         },
         "run-parallel": {

--- a/modular-particle-system/package.json
+++ b/modular-particle-system/package.json
@@ -10,8 +10,9 @@
         "test": "npx jest",
         "compile": "npm run compile:clean && tsc && tsc-esm dist/**/*.js && npm run test-minify",
         "compile:clean": "rm -rf dist",
+        "rollup": "rollup dist/particleSystem.js --file dist/index.iife.js --format iife --name modularParticleSystem",
         "release": "npm run release:build && cd release && npm publish",
-        "release:build": "npm run release:clean && npm run compile && mkdir release && cp -r LICENSE README.md CHANGELOG.md package.json dist/** release",
+        "release:build": "npm run release:clean && npm run compile && npm run rollup && mkdir release && cp -r LICENSE README.md CHANGELOG.md package.json dist/** release",
         "release:clean": "rm -rf release",
         "test-minify": "rm -rf min && node test-minify.js",
         "ci:code-style": "npm run lint"
@@ -30,6 +31,7 @@
         "jest-canvas-mock": "^2.3.1",
         "prettier": "^2.5.1",
         "rimraf": "^3.0.2",
+        "rollup": "^2.70.2",
         "through2": "^2.0.5",
         "ts-jest": "^27.1.3",
         "tsc-esm": "^1.0.4",


### PR DESCRIPTION
This allows anyone to use the Particle system directly from any web page simply by adding a script like this to the HTML:

`<script src="https://cdn.jsdelivr.net/npm/modular-particle-system@1.1.0/index.iife.js"></script>`