### PR TITLE
Make editor usable on mobile (without editing options)

### DIFF
--- a/editor/src/components/EffectsConfigurationPanel/EffectsConfigurationPanel.css
+++ b/editor/src/components/EffectsConfigurationPanel/EffectsConfigurationPanel.css
@@ -10,6 +10,14 @@
   z-index: 1000;
   background: #fff;
 }
+
+@media screen and (max-width: 768px) {
+  .effectsConfigurationPanel {
+    display: none;
+    width: 0px;
+  }
+}
+
 /* Hide scrollbar for Chrome, Safari and Opera */
 .effectsConfigurationPanel::-webkit-scrollbar {
   display: none;

--- a/editor/src/components/ProjectToolbar.css
+++ b/editor/src/components/ProjectToolbar.css
@@ -1,5 +1,4 @@
 .projectToolbar {
-  height: 50px;
   display: flex;
   flex-direction: column;
   border-bottom: solid 1px;
@@ -89,4 +88,15 @@
 .projectToolbar-saveToFile {
 }
 .projectToolbar-loadFromFile {
+}
+
+@media screen and (max-width: 768px) {
+  .projectToolbar-saveToFile {
+    display: none;
+    width: 0px;
+  }
+  .projectToolbar-loadFromFile {
+    display: none;
+    width: 0px;
+  }
 }


### PR DESCRIPTION
On mobile (small screens) removes following stuff from view:
- Save/load from file buttons
- Effect editor panel

This makes it possible to check out the particle library on mobile, but not edit effects. Previously neither was realistically possible.